### PR TITLE
Fix utils and get_parent_process_name().

### DIFF
--- a/userpath/utils.py
+++ b/userpath/utils.py
@@ -4,7 +4,7 @@ import subprocess
 try:
     import psutil
 except Exception:
-    pass
+    psutil = None
 
 
 def normpath(location):
@@ -51,7 +51,8 @@ def get_parent_process_name():
                 pass
 
         ppid = os.getppid()
-        return subprocess.check_output(['ps', '-o', 'cmd=', str(ppid)]).decode('utf-8').strip()
+        process_name = subprocess.check_output(['ps', '-o', 'args=', str(ppid)]).decode('utf-8')
+        return process_name.strip().lstrip("-")
     except Exception:
         pass
 


### PR DESCRIPTION
Closes #30 

I modified `utils.py` so that `psutil` does not raise a `NameError` in the case when `psutil` is not present.  The original code of `get_parent_process_name()` would always raise an Exception in the past just from checking `if psutil:` if `psutil` was not successfully imported, and thus would always return the empty string `""` without being able to fall back on executing the `ps` subprocess.

In addition, I used `args=` instead of `cmd=` in the `ps` command, because it is a synonym and is more universal.  `args=` works on macOS (and presumably BSD) but `cmd=` does not.

I also removed a preceding `-` from the process name, in case the shell was called as a login shell.