### PR TITLE
bash: create either ~/.profile or ~/.bash_profile depending on which exist only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
     ],
 
     install_requires=REQUIRES,
-    extras_require={':platform_system == "Linux"': ['distro']},
     packages=['userpath'],
     entry_points={
         'console_scripts': [

--- a/userpath/shells.py
+++ b/userpath/shells.py
@@ -34,7 +34,7 @@ class Bash(Shell):
 
         # https://github.com/ofek/userpath/issues/3#issuecomment-492491977
         profile_path = path.join(self.home, '.profile')
-        bash_profile_path profile_path = path.join(self.home, '.bash_profile')
+        bash_profile_path = path.join(self.home, '.bash_profile')
 
         if path.exists(profile_path) and not path.exists(bash_profile_path):
             login_config = profile_path

--- a/userpath/shells.py
+++ b/userpath/shells.py
@@ -1,9 +1,5 @@
 from os import path, pathsep
 
-try:
-    import distro
-except ImportError:  # pragma: no cover
-    distro = None
 
 DEFAULT_SHELLS = ('bash', 'sh')
 
@@ -37,13 +33,16 @@ class Bash(Shell):
         configs = {path.join(self.home, '.bashrc'): contents}
 
         # https://github.com/ofek/userpath/issues/3#issuecomment-492491977
-        if distro and distro.id() == 'ubuntu':  # pragma: no cover
-            login_config = path.join(self.home, '.profile')
+        profile_path = path.join(self.home, '.profile')
+        bash_profile_path profile_path = path.join(self.home, '.bash_profile')
+
+        if path.exists(profile_path) and not path.exists(bash_profile_path):
+            login_config = profile_path
         else:
             # NOTE: If it is decided in future that we want to make a distinction between
             # login and non-login shells, be aware that macOS will still need this since
             # Terminal.app runs a login shell by default for each new terminal window.
-            login_config = path.join(self.home, '.bash_profile')
+            login_config = bash_profile_path
 
         configs[login_config] = contents
 


### PR DESCRIPTION
This my attempt to fix #19 

The logic here is attempting to code @AlJohri's mention of what files to modify from https://github.com/ofek/userpath/issues/3#issuecomment-512973913, specifically:
> profile/bash_profile means use whichever file already exists, defaulting to bash_profile

I dispensed with checking if we're on the ubuntu distro (and the `distro` dependency) in favor of just noting which of `~/.profile` and/or `~/.bash_profile` exist.  I pick one, and only upgrade `~/.profile` if it is the only one that currently exists in a user's home directory.

I wasn't able to get the tests working in my local computer (possibly because I'm on macOS) so hopefully on a pull request the CI will test this code.