### PR TITLE
Encode stdout from subprocess.Popen command using locale's encoding.

### DIFF
--- a/userpath/utils.py
+++ b/userpath/utils.py
@@ -1,3 +1,4 @@
+import locale
 import os
 import subprocess
 
@@ -30,7 +31,7 @@ def ensure_parent_dir_exists(path):
 
 def get_flat_output(command, sep=os.pathsep, **kwargs):
     process = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
-    output = process.communicate()[0].decode('utf-8').strip()
+    output = process.communicate()[0].decode(locale.getpreferredencoding(False)).strip()
 
     # We do this because the output may contain new lines.
     lines = [line.strip() for line in output.splitlines()]


### PR DESCRIPTION
Closes #35 .

This modifies `userpath.utils.get_flat_output()` to encode the result from stdout using the locale's preferred encoding (presumably what is being used to encode the output of the `subprocess.Popen` stdout).  We use `locale.getpreferredencoding(False)` to accomplish this to ensure maximum compatibility back to Python 2.7.

Previously the code used hard-coded `"utf-8"` encoding to decode stdout, and this may not be correct for some platforms, possibly resulting in a `UnicodeError`.