### PR TITLE
add missing import for ctypes.wintypes

### DIFF
--- a/userpath/interface.py
+++ b/userpath/interface.py
@@ -39,6 +39,7 @@ class WindowsInterface:
 
     def put(self, location, front=True, check=False, **kwargs):
         import ctypes
+        import ctypes.wintypes
 
         location = normpath(location)
 


### PR DESCRIPTION
Add missing import of `ctypes.wintypes`.
See #55